### PR TITLE
src/*/Makefile.include: remove extra "src/" in filenames

### DIFF
--- a/src/class/Makefile.include
+++ b/src/class/Makefile.include
@@ -20,23 +20,23 @@
 #
 
 # This makefile.am does not stand on its own - it is included from
-# src/Makefile.am
+# Makefile.am
 
 # Source code files
 headers += \
-        src/class/pmix_object.h \
-        src/class/pmix_list.h \
-        src/class/pmix_pointer_array.h \
-        src/class/pmix_hash_table.h \
-        src/class/pmix_hotel.h \
-        src/class/pmix_ring_buffer.h \
-        src/class/pmix_value_array.h
+        class/pmix_object.h \
+        class/pmix_list.h \
+        class/pmix_pointer_array.h \
+        class/pmix_hash_table.h \
+        class/pmix_hotel.h \
+        class/pmix_ring_buffer.h \
+        class/pmix_value_array.h
 
 sources += \
-        src/class/pmix_object.c \
-        src/class/pmix_list.c \
-        src/class/pmix_pointer_array.c \
-        src/class/pmix_hash_table.c \
-        src/class/pmix_hotel.c \
-        src/class/pmix_ring_buffer.c \
-        src/class/pmix_value_array.c
+        class/pmix_object.c \
+        class/pmix_list.c \
+        class/pmix_pointer_array.c \
+        class/pmix_hash_table.c \
+        class/pmix_hotel.c \
+        class/pmix_ring_buffer.c \
+        class/pmix_value_array.c

--- a/src/client/Makefile.include
+++ b/src/client/Makefile.include
@@ -12,18 +12,18 @@
 #
 
 headers += \
-        src/client/pmix_client_ops.h
+        client/pmix_client_ops.h
 
 sources += \
-        src/client/pmix_client.c \
-        src/client/pmix_client_fence.c \
-        src/client/pmix_client_get.c \
-        src/client/pmix_client_pub.c \
-        src/client/pmix_client_spawn.c \
-        src/client/pmix_client_connect.c
+        client/pmix_client.c \
+        client/pmix_client_fence.c \
+        client/pmix_client_get.c \
+        client/pmix_client_pub.c \
+        client/pmix_client_spawn.c \
+        client/pmix_client_connect.c
 
 if !PMIX_EMBEDDED_MODE
 sources += \
-        src/client/pmi1.c \
-        src/client/pmi2.c
+        client/pmi1.c \
+        client/pmi2.c
 endif

--- a/src/common/Makefile.include
+++ b/src/common/Makefile.include
@@ -10,4 +10,4 @@
 #
 
 sources += \
-        src/common/pmix_common.c
+        common/pmix_common.c

--- a/src/dstore/Makefile.include
+++ b/src/dstore/Makefile.include
@@ -11,9 +11,9 @@
 
 
 headers += \
-        src/dstore/pmix_dstore.h \
-        src/dstore/pmix_esh.h
+        dstore/pmix_dstore.h \
+        dstore/pmix_esh.h
 
 sources += \
-        src/dstore/pmix_dstore.c \
-        src/dstore/pmix_esh.c
+        dstore/pmix_dstore.c \
+        dstore/pmix_esh.c

--- a/src/include/Makefile.include
+++ b/src/include/Makefile.include
@@ -19,33 +19,33 @@
 # $HEADER$
 #
 
-EXTRA_DIST += src/include/private/autogen/README.txt
+EXTRA_DIST += include/private/autogen/README.txt
 
 # This makefile.am does not stand on its own - it is included from
-# src/Makefile.am
+# Makefile.am
 
 headers += \
-        src/include/pmix_globals.h
+        include/pmix_globals.h
 
 sources += \
-        src/include/pmix_globals.c
+        include/pmix_globals.c
 
 if ! PMIX_EMBEDDED_MODE
 headers += \
-        src/include/pmix_config.h \
-        src/include/align.h \
-        src/include/hash_string.h \
-        src/include/pmix_socket_errno.h \
-        src/include/pmix_stdint.h \
-        src/include/prefetch.h \
-        src/include/types.h
+        include/pmix_config.h \
+        include/align.h \
+        include/hash_string.h \
+        include/pmix_socket_errno.h \
+        include/pmix_stdint.h \
+        include/prefetch.h \
+        include/types.h
 
 #include_private_autogendir = $(includedir)/private/autogen
 #noinst_include_private_autogen_HEADERS = \
-#        src/include/private/autogen/config.h
+#        include/private/autogen/config.h
 endif ! PMIX_EMBEDDED_MODE
 
 if WANT_INSTALL_HEADERS
 headers += \
-    src/include/private/autogen/config.h
+    include/private/autogen/config.h
 endif

--- a/src/sec/Makefile.include
+++ b/src/sec/Makefile.include
@@ -10,25 +10,25 @@
 #
 
 headers += \
-        src/sec/pmix_sec.h \
-        src/sec/pmix_native.h
+        sec/pmix_sec.h \
+        sec/pmix_native.h
 
 sources += \
-        src/sec/pmix_sec.c \
-        src/sec/pmix_native.c
+        sec/pmix_sec.c \
+        sec/pmix_native.c
 
 if PMIX_WANT_MUNGE
 headers += \
-        src/sec/pmix_munge.h
+        sec/pmix_munge.h
 
 sources += \
-        src/sec/pmix_munge.c
+        sec/pmix_munge.c
 endif
 
 if PMIX_WANT_SASL
 headers += \
-        src/sec/pmix_sasl.h
+        sec/pmix_sasl.h
 
 sources += \
-        src/sec/pmix_sasl.c
+        sec/pmix_sasl.c
 endif

--- a/src/server/Makefile.include
+++ b/src/server/Makefile.include
@@ -12,11 +12,11 @@
 #
 
 headers += \
-        src/server/pmix_server_ops.h
+        server/pmix_server_ops.h
 
 sources += \
-        src/server/pmix_server.c \
-        src/server/pmix_server_ops.c \
-        src/server/pmix_server_regex.c \
-        src/server/pmix_server_listener.c \
-        src/server/pmix_server_get.c
+        server/pmix_server.c \
+        server/pmix_server_ops.c \
+        server/pmix_server_regex.c \
+        server/pmix_server_listener.c \
+        server/pmix_server_get.c

--- a/src/sm/Makefile.include
+++ b/src/sm/Makefile.include
@@ -11,9 +11,9 @@
 #
 
 headers += \
-        src/sm/pmix_sm.h \
-        src/sm/pmix_mmap.h
+        sm/pmix_sm.h \
+        sm/pmix_mmap.h
 
 sources += \
-        src/sm/pmix_sm.c \
-        src/sm/pmix_mmap.c
+        sm/pmix_sm.c \
+        sm/pmix_mmap.c

--- a/src/usock/Makefile.include
+++ b/src/usock/Makefile.include
@@ -12,8 +12,8 @@
 #
 
 headers += \
-        src/usock/usock.h
+        usock/usock.h
 
 sources += \
-        src/usock/usock.c \
-        src/usock/usock_sendrecv.c
+        usock/usock.c \
+        usock/usock_sendrecv.c

--- a/src/util/Makefile.include
+++ b/src/util/Makefile.include
@@ -26,38 +26,38 @@ LEX_OUTPUT_ROOT = lex.pmix_show_help_yy
 # Source code files
 
 headers += \
-        src/util/argv.h \
-        src/util/error.h \
-        src/util/printf.h \
-        src/util/output.h \
-        src/util/pmix_environ.h \
-        src/util/crc.h \
-        src/util/progress_threads.h \
-        src/util/fd.h \
-        src/util/timings.h \
-        src/util/os_path.h \
-        src/util/basename.h \
-        src/util/hash.h \
-        src/util/keyval_parse.h \
-        src/util/cmd_line.h \
-        src/util/show_help.h \
-        src/util/show_help_lex.h \
-        src/util/path.h
+        util/argv.h \
+        util/error.h \
+        util/printf.h \
+        util/output.h \
+        util/pmix_environ.h \
+        util/crc.h \
+        util/progress_threads.h \
+        util/fd.h \
+        util/timings.h \
+        util/os_path.h \
+        util/basename.h \
+        util/hash.h \
+        util/keyval_parse.h \
+        util/cmd_line.h \
+        util/show_help.h \
+        util/show_help_lex.h \
+        util/path.h
 
 sources += \
-        src/util/argv.c \
-        src/util/error.c \
-        src/util/printf.c \
-        src/util/output.c \
-        src/util/pmix_environ.c \
-        src/util/crc.c \
-        src/util/progress_threads.c \
-        src/util/fd.c \
-        src/util/timings.c \
-        src/util/os_path.c \
-        src/util/basename.c \
-        src/util/hash.c \
-        src/util/keyval_parse.c \
-        src/util/cmd_line.c \
-        src/util/show_help.c \
-        src/util/path.c
+        util/argv.c \
+        util/error.c \
+        util/printf.c \
+        util/output.c \
+        util/pmix_environ.c \
+        util/crc.c \
+        util/progress_threads.c \
+        util/fd.c \
+        util/timings.c \
+        util/os_path.c \
+        util/basename.c \
+        util/hash.c \
+        util/keyval_parse.c \
+        util/cmd_line.c \
+        util/show_help.c \
+        util/path.c


### PR DESCRIPTION
Signed-off-by: Jeff Squyres jsquyres@cisco.com
