### PR TITLE
gds/hash: removes double invoke `free` for `nptr`

### DIFF
--- a/src/mca/gds/hash/gds_hash.c
+++ b/src/mca/gds/hash/gds_hash.c
@@ -120,9 +120,6 @@ static void htdes(pmix_hash_trkr_t *p)
     if (NULL != p->ns) {
         free(p->ns);
     }
-    if (NULL != p->nptr) {
-        PMIX_RELEASE(p->nptr);
-    }
     PMIX_DESTRUCT(&p->internal);
     PMIX_DESTRUCT(&p->remote);
     PMIX_DESTRUCT(&p->local);


### PR DESCRIPTION
This `free` already called by 'PMIx_server_deregister_nspace'

Signed-off-by: Boris Karasev <karasev.b@gmail.com>