### PR TITLE
Fixed client 'commit' callback

### DIFF
--- a/src/client/pmix_client.c
+++ b/src/client/pmix_client.c
@@ -964,7 +964,7 @@ static void _commitfn(int sd, short args, void *cbdata)
      * that we contributed whatever we had */
     PMIX_PTL_SEND_RECV(rc, &pmix_client_globals.myserver, msgout,
                        wait_cbfunc, (void*)&cb->active);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_SUCCESS == rc) {
         cb->pstatus = PMIX_SUCCESS;
         return;
     }


### PR DESCRIPTION
Fixes a case when 'commit' request status was successful, but
client doesn't wait for server answer. In this case it worked
as non-blocking 'commit' and as a result incorrect.

Signed-off-by: Boris Karasev <karasev.b@gmail.com>